### PR TITLE
fix: add missing lang argument + add download progress callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,9 @@ ndarray-npy = "0.10.0"
 
 # Minimal async support for downloading model
 tokio = { version = "1.45", features = ["fs", "rt"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+futures-util = "0.3"  # For StreamExt in download progress
+bytes = "1"  # For Bytes type in streaming
 
 # For voice data loading and MCP server
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/all_voices.rs
+++ b/examples/all_voices.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for voice in &english_voices {
         println!("🔊 Voice: {}", voice);
 
-        match tts.synthesize(text, Some(voice)) {
+        match tts.synthesize(text, Some(voice), None, None) {
             Ok(audio) => {
                 let duration_secs = audio.len() as f32 / 24000.0;
                 println!(

--- a/examples/debug_tokens.rs
+++ b/examples/debug_tokens.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The library doesn't expose tokenize publicly, so let's trace what happens
     println!("Testing with actual synthesis...");
 
-    match tts.synthesize_with_speed(text, Some("af_sky"), 1.0) {
+    match tts.synthesize_with_speed(text, Some("af_sky"), 1.0, None) {
         Ok(audio) => {
             println!("✅ Synthesis succeeded!");
             println!(

--- a/examples/debug_words.rs
+++ b/examples/debug_words.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for speed in &[0.5, 0.85, 1.0] {
             println!("  Speed {}x:", speed);
 
-            match tts.synthesize_with_speed(phrase, None, *speed) {
+            match tts.synthesize_with_speed(phrase, None, *speed, None) {
                 Ok(audio) => {
                     let filename = format!("debug_{}_speed_{}.wav", i + 1, (speed * 100.0) as u32);
                     tts.save_wav(&filename, &audio)?;

--- a/examples/demo_fix.rs
+++ b/examples/demo_fix.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("📝 Aye says:\n\"{}\"\n", message);
 
     // Synthesize with our fix
-    let audio = tts.synthesize_with_speed(message, Some("af_sky"), 1.0)?;
+    let audio = tts.synthesize_with_speed(message, Some("af_sky"), 1.0, None)?;
 
     println!(
         "✅ Generated {} audio samples ({:.1} seconds)",

--- a/examples/device_select.rs
+++ b/examples/device_select.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tts.set_audio_device(Some(device.clone()))?;
 
             // Synthesize and play
-            let audio = tts.synthesize(text, None)?;
+            let audio = tts.synthesize(text, None, None, None)?;
             tts.play(&audio, 0.8)?;
 
             println!("✅ Playback complete\n");
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Reset to default
         println!("🔄 Resetting to system default device");
         tts.set_audio_device(None)?;
-        let audio = tts.synthesize("Back to default device.", None)?;
+        let audio = tts.synthesize("Back to default device.", None, None, None)?;
         tts.play(&audio, 0.8)?;
     }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let text = "Hello from kokoro-tiny! This is a minimal text to speech engine.";
     println!("Synthesizing: \"{}\"\n", text);
 
-    let audio = tts.synthesize(text, None)?;
+    let audio = tts.synthesize(text, None, None, None)?;
     println!("✅ Generated {} audio samples", audio.len());
 
     // Save to file

--- a/examples/story_time.rs
+++ b/examples/story_time.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("🎤 Generating audio with proper punctuation pauses...\n");
 
     // Use the working v2 branch implementation with punctuation pauses
-    let audio = tts.synthesize_with_speed(story, Some("af_sky"), 1.0)?;
+    let audio = tts.synthesize_with_speed(story, Some("af_sky"), 1.0, None)?;
 
     println!(
         "✅ Generated {} samples ({:.1}s)",

--- a/examples/test_american.rs
+++ b/examples/test_american.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Text: \"{}\"", text);
     println!("Voice: am_adam (American Male)\n");
 
-    let audio = tts.synthesize_with_speed(text, Some("am_adam"), 1.0)?;
+    let audio = tts.synthesize_with_speed(text, Some("am_adam"), 1.0, None)?;
 
     tts.save_wav("american_test.wav", &audio)?;
     println!("✅ Saved to american_test.wav");

--- a/examples/test_backwards_compat.rs
+++ b/examples/test_backwards_compat.rs
@@ -12,13 +12,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Old API style (3 parameters with speed)
     println!("1️⃣ Testing old synthesize(text, voice, Some(speed)):");
-    let audio1 = tts.synthesize_with_speed(text, Some("af_sky"), 1.0)?;
+    let audio1 = tts.synthesize_with_speed(text, Some("af_sky"), 1.0, None)?;
     println!("   ✅ Works! {} samples", audio1.len());
 
     // Old API style (3 parameters with None speed)
     println!("\n2️⃣ Testing old synthesize(text, voice, None):");
     // Older code passing None speed will be interpreted as default speed
-    let audio2 = tts.synthesize(text, Some("af_sky"))?;
+    let audio2 = tts.synthesize(text, Some("af_sky"), None, None)?;
     println!("   ✅ Works! {} samples", audio2.len());
 
     // Old API style (process_long_text)
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // New API style (just 2 params - for those who migrated)
     println!("\n5️⃣ Testing new synthesize_with_speed(text, voice, speed):");
-    let audio5 = tts.synthesize_with_speed(text, Some("af_sky"), 1.0)?;
+    let audio5 = tts.synthesize_with_speed(text, Some("af_sky"), 1.0, None)?;
     println!("   ✅ Works! {} samples", audio5.len());
 
     println!("\n🎉 ALL BACKWARDS COMPATIBILITY TESTS PASSED!");

--- a/examples/test_english.rs
+++ b/examples/test_english.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Text: \"{}\"", text);
 
-    let audio = tts.synthesize_with_speed(text, Some("af_sky"), 1.0)?;
+    let audio = tts.synthesize_with_speed(text, Some("af_sky"), 1.0, None)?;
 
     tts.save_wav("test_english.wav", &audio)?;
     println!("✅ Saved to test_english.wav ({} samples)", audio.len());

--- a/examples/test_v2_punctuation.rs
+++ b/examples/test_v2_punctuation.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Text: \"{}\"", text);
 
-    let audio = tts.synthesize(text, Some("af_sky"))?;
+    let audio = tts.synthesize(text, Some("af_sky"), None, None)?;
 
     println!(
         "\nAudio length: {} samples ({:.1}s)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ use rodio::{Decoder, OutputStream, Sink};
 // Cursor is used for in-memory audio operations, not just playback
 use std::io::Cursor;
 
+// Async I/O for streaming downloads
+use tokio::io::AsyncWriteExt;
+use futures_util::StreamExt;
+
 #[cfg(feature = "ducking")]
 use enigo::{Enigo, Key, Keyboard, Settings};
 
@@ -75,6 +79,46 @@ const PAD_TOKEN: char = '$'; // Padding token for beginning/end of phonemes
 // Fallback audio message - "Excuse me, I lost my voice. Give me time to get it back."
 // This is a pre-generated minimal WAV file that can play while downloading
 const FALLBACK_MESSAGE: &[u8] = include_bytes!("../assets/fallback.wav");
+
+// Progress types for download tracking
+/// Progress information for downloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Progress {
+    /// Number of bytes downloaded so far
+    pub bytes_downloaded: u64,
+    /// Total bytes to download
+    pub total_bytes: u64,
+    /// Which file is currently being downloaded
+    pub current_file: FileType,
+}
+
+impl Progress {
+    /// Returns the download percentage (0-100)
+    pub fn percent(&self) -> u32 {
+        if self.total_bytes == 0 {
+            return 100;
+        }
+        (self.bytes_downloaded as f64 / self.total_bytes as f64 * 100.0) as u32
+    }
+}
+
+/// Which file type is currently being downloaded
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileType {
+    /// The main ONNX model file
+    Model,
+    /// Voice pack file
+    Voices,
+}
+
+impl std::fmt::Display for FileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileType::Model => write!(f, "model"),
+            FileType::Voices => write!(f, "voices"),
+        }
+    }
+}
 
 // Get cache directory for shared model storage - keeping it minimal like Hue wants!
 fn get_cache_dir() -> PathBuf {
@@ -354,6 +398,140 @@ impl TtsEngine {
         Ok(engine)
     }
 
+    /// Create engine with custom paths and optional progress callback.
+    ///
+    /// This method allows you to track download progress when initializing
+    /// the TTS engine.
+    pub async fn with_progress<P>(
+        model_path: &str,
+        voices_path: &str,
+        on_progress: P,
+    ) -> Result<Self, String>
+    where
+        P: Fn(Progress) + Clone + Send + Sync + 'static,
+    {
+        use bytes::Bytes;
+
+        if let Some(parent) = Path::new(model_path).parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create cache directory: {}", e))?;
+        }
+
+        let model_exists = Path::new(model_path).exists();
+        let voices_exists = Path::new(voices_path).exists();
+
+        if !model_exists || !voices_exists {
+            #[cfg(not(feature = "as-lib"))]
+            println!("🎤 Downloading voice model...");
+            #[cfg(not(feature = "as-lib"))]
+            println!("   (Files will be cached in ~/.cache/k)");
+
+            #[cfg(feature = "playback")]
+            {
+                thread::spawn(|| {
+                    if let Err(e) = play_fallback_message() {
+                        eprintln!("   ℹ️  Could not play fallback message: {}", e);
+                    }
+                });
+            }
+
+            let download_success = {
+                let mut success = true;
+
+                const MODEL_SIZE: u64 = 325_000_000;
+                const VOICES_SIZE: u64 = 28_000_000;
+
+                if !model_exists {
+                    #[cfg(not(feature = "as-lib"))]
+                    println!("   📥 Downloading model...");
+
+                    let on_progress = on_progress.clone();
+                    if let Err(e) = download_file_with_progress(
+                        MODEL_URL, model_path,
+                        Some(Box::new(move |p| on_progress(p))),
+                        MODEL_SIZE,
+                    ).await {
+                        #[cfg(not(feature = "as-lib"))]
+                        eprintln!("   ❌ Failed to download model: {}", e);
+                        success = false;
+                    }
+                }
+
+                if success && !voices_exists {
+                    #[cfg(not(feature = "as-lib"))]
+                    println!("   📥 Downloading voices...");
+
+                    let on_progress = on_progress.clone();
+                    if let Err(e) = download_file_with_progress(
+                        VOICES_URL, voices_path,
+                        Some(Box::new(move |p| on_progress(p))),
+                        VOICES_SIZE,
+                    ).await {
+                        #[cfg(not(feature = "as-lib"))]
+                        eprintln!("   ❌ Failed to download voices: {}", e);
+                        success = false;
+                    }
+                }
+
+                if success {
+                    #[cfg(not(feature = "as-lib"))]
+                    println!("   ✅ Voice model downloaded successfully!");
+                }
+
+                success
+            };
+
+            if !download_success {
+                #[cfg(not(feature = "as-lib"))]
+                eprintln!("\n⚠️  Using fallback mode.");
+                return Ok(Self {
+                    session: None,
+                    voices: HashMap::new(),
+                    vocab: build_vocab(),
+                    fallback_mode: true,
+                    #[cfg(feature = "playback")]
+                    audio_device: None,
+                });
+            }
+        }
+
+        let model_bytes =
+            std::fs::read(model_path).map_err(|e| format!("Failed to read model file: {}", e))?;
+        let session = Session::builder()
+            .map_err(|e| format!("Failed to create session builder: {}", e))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| format!("Failed to set optimization level: {}", e))?
+            .commit_from_memory(&model_bytes)
+            .map_err(|e| format!("Failed to load model: {}", e))?;
+
+        let voices = load_voices(voices_path)?;
+
+        let mut engine = Self {
+            session: Some(Arc::new(Mutex::new(session))),
+            voices,
+            vocab: build_vocab(),
+            fallback_mode: false,
+            #[cfg(feature = "playback")]
+            audio_device: None,
+        };
+
+        #[cfg(feature = "playback")]
+        {
+            if engine.audio_device.is_none() {
+                if let Some(cached) = load_cached_device() {
+                    engine.audio_device = Some(cached);
+                } else if let Ok(devs) = engine.list_audio_devices() {
+                    if let Some(pref) = pick_preferred_device(&devs) {
+                        let _ = save_cached_device(Some(&pref));
+                        engine.audio_device = Some(pref);
+                    }
+                }
+            }
+        }
+
+        Ok(engine)
+    }
+
     /// List all available voices
     pub fn voices(&self) -> Vec<String> {
         if self.fallback_mode {
@@ -476,7 +654,7 @@ impl TtsEngine {
         speed: Option<f32>,
     ) -> Result<Vec<f32>, String> {
         // Forward to speed-aware variant (use default if None)
-        self.synthesize_with_speed(text, voice, speed.unwrap_or(DEFAULT_SPEED), Some(lang.unwrap_or(DEFAULT_LANG)))
+        self.synthesize_with_speed(text, voice, speed.unwrap_or(DEFAULT_SPEED), None)
     }
 
     /// Synthesize speech from text with validation warnings (backwards compatibility)
@@ -500,7 +678,7 @@ impl TtsEngine {
             ));
         }
 
-        let audio = self.synthesize_with_speed(text, voice, speed.unwrap_or(DEFAULT_SPEED), Some(lang.unwrap_or(DEFAULT_LANG)))?;
+        let audio = self.synthesize_with_speed(text, voice, speed.unwrap_or(DEFAULT_SPEED), None)?;
         Ok((audio, warnings))
     }
 
@@ -1040,15 +1218,43 @@ fn load_voices(path: &str) -> Result<HashMap<String, Vec<f32>>, String> {
     Ok(voices)
 }
 
-// Download file from URL
-async fn download_file(url: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let response = reqwest::get(url).await?;
-    let bytes = response.bytes().await?;
+// Download file with optional progress callback
+async fn download_file_with_progress(
+    url: &str,
+    path: &str,
+    progress_callback: Option<Box<dyn Fn(Progress) + Send + 'static>>,
+    expected_size: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use bytes::Bytes;
 
-    let mut file = File::create(path)?;
-    file.write_all(&bytes)?;
+    let client = reqwest::Client::new();
+    let response = client.get(url).send().await?;
+
+    let mut file = tokio::fs::File::create(path).await?;
+    let mut stream = response.bytes_stream();
+    let mut downloaded: u64 = 0;
+
+    while let Some(item) = stream.next().await {
+        let chunk: Bytes = item?;
+        let chunk_len = chunk.len();
+        file.write_all(&chunk).await?;
+        downloaded += chunk_len as u64;
+
+        if let Some(ref callback) = progress_callback {
+            callback(Progress {
+                bytes_downloaded: downloaded,
+                total_bytes: expected_size,
+                current_file: FileType::Model,
+            });
+        }
+    }
 
     Ok(())
+}
+
+// Download file from URL
+async fn download_file(url: &str, path: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    download_file_with_progress(url, path, None, 0).await
 }
 
 // Play the fallback message (used during first-time download)
@@ -1453,5 +1659,32 @@ mod tests {
         let long = "This sentence is intentionally quite a bit longer than the \
                     short sample so that it exceeds the chunking threshold we set.";
         assert!(needs_chunking(long));
+    }
+
+    // Progress type tests
+    #[test]
+    fn progress_percent_calculation() {
+        let progress = Progress {
+            bytes_downloaded: 50_000_000,
+            total_bytes: 100_000_000,
+            current_file: FileType::Model,
+        };
+        assert_eq!(progress.percent(), 50);
+    }
+
+    #[test]
+    fn progress_percent_zero_total() {
+        let progress = Progress {
+            bytes_downloaded: 50,
+            total_bytes: 0,
+            current_file: FileType::Model,
+        };
+        assert_eq!(progress.percent(), 100);
+    }
+
+    #[test]
+    fn progress_file_type_display() {
+        assert_eq!(FileType::Model.to_string(), "model");
+        assert_eq!(FileType::Voices.to_string(), "voices");
     }
 }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -11,7 +11,7 @@
 
 use crate::TtsEngine;
 use serde::{Deserialize, Serialize};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, Read, Write};
 
 /// MCP Protocol version
 const PROTOCOL_VERSION: &str = "2024-11-05";
@@ -94,10 +94,19 @@ impl McpServer {
         eprintln!("📡 Protocol version: {}", PROTOCOL_VERSION);
         eprintln!("🔊 Ready to provide audio collaboration!");
 
-        for line in self.stdin.by_ref().lines() {
-            let line = line.map_err(|e| format!("Failed to read line: {}", e))?;
-            
-            if line.trim().is_empty() {
+        loop {
+            let mut line = String::new();
+            match self.stdin.read_line(&mut line) {
+                Ok(0) => break, // EOF
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("Failed to read line: {}", e);
+                    continue;
+                }
+            }
+
+            let line = line.trim();
+            if line.is_empty() {
                 continue;
             }
 
@@ -336,7 +345,7 @@ impl McpServer {
         eprintln!("🔊 Speaking: \"{}\" with voice {:?}", text, voice);
 
         // Synthesize audio
-        let audio = self.tts.synthesize_with_speed(text, voice, speed)
+        let audio = self.tts.synthesize_with_speed(text, voice, speed, None)
             .map_err(|e| McpError {
                 code: -32603,
                 message: format!("Synthesis failed: {}", e),
@@ -413,7 +422,7 @@ impl McpServer {
         eprintln!("😊 Speaking with emotion '{}': voice={}", emotion, voice);
 
         // Synthesize and play
-        let audio = self.tts.synthesize_with_speed(text, Some(voice), speed)
+        let audio = self.tts.synthesize_with_speed(text, Some(voice), speed, None)
             .map_err(|e| McpError {
                 code: -32603,
                 message: format!("Synthesis failed: {}", e),
@@ -514,7 +523,7 @@ impl McpServer {
         eprintln!("💾 Saving to file: {}", output_path);
 
         // Synthesize audio
-        let audio = self.tts.synthesize_with_speed(text, voice, speed)
+        let audio = self.tts.synthesize_with_speed(text, voice, speed, None)
             .map_err(|e| McpError {
                 code: -32603,
                 message: format!("Synthesis failed: {}", e),


### PR DESCRIPTION
Hello and thank you for working on making kokoro-tiny!
My PR is about some fixes and also an added feature!
I hope you will find it useful!

Progress Callback + Bug Fixes

## Summary

Single PR containing:
1. **Bug fixes** for MCP server and synthesis API
2. **New feature**: Download progress callbacks for TTS engine initialization

## Bug Fixes

### 1. Missing `lang` argument in API calls
- Fixed undefined `lang` variable in `process_long_text()` and `synthesize_with_warnings()`
- Added 4th `None` argument to all `synthesize_with_speed()` calls in examples

### 2. MCP server stdin reading
- Fixed `stdin.by_ref().lines()` borrow checker issue with proper loop

### 3. Example updates
- All examples updated to use new 4-argument API

## New Feature: Download Progress Callbacks

### API

```rust
use kokoro_tiny::{TtsEngine, Progress};

let engine = TtsEngine::with_progress(
    "model.onnx",
    "voices.bin",
    |progress: Progress| {
        println!("\rDownloading: {}% ({}/{} MB)",
            progress.percent(),
            progress.bytes_downloaded / 1_000_000,
            progress.total_bytes / 1_000_000
        );
    }
).await?;
```

### Types

```rust
pub struct Progress {
    pub bytes_downloaded: u64,
    pub total_bytes: u64,
    pub current_file: FileType,  // Model or Voices
}

pub enum FileType {
    Model,   // ~310MB
    Voices,  // ~27MB
}
```

## Files Changed

| File | Changes |
|------|---------|
| `Cargo.toml` | Add `futures-util`, `bytes`, `reqwest/stream` |
| `src/lib.rs` | Add Progress/FileType, with_progress(), download_file_with_progress() |
| `src/mcp_server.rs` | Fix stdin loop, add lang argument |
| `examples/*.rs` | Update API calls |

## Testing

```bash
cargo test --lib  # 7 tests pass
cargo build       # Builds successfully
```


